### PR TITLE
Change engine code in drops.lua to not let spectators pick up items.

### DIFF
--- a/mods/engine/bs_drops/init.lua
+++ b/mods/engine/bs_drops/init.lua
@@ -46,3 +46,16 @@ core.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool
 end)
 
 minetest.register_on_leaveplayer(dropondie.drop_all)
+
+--[[
+if bs.spectator[Name(hitter)] or bs.spectator[Name(player)] then -- Dont allow spectators do damage.
+		return true
+	end
+]]--
+
+minetest.register_on_item_pickup(
+	function(itemstack, picker, pointed_thing, time_from_last_punch)
+		if bs.spectator[Name(picker)] or bs.spectator[Name(picker)] then
+			return Itemstack("")
+		end
+	end)


### PR DESCRIPTION
make spectators not pick up items.

You will have to test this because I am still away for another week and can't test MT stuff rn.